### PR TITLE
Update ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-Roadmap
+This Roadmap is out-of-date and it is no longer maintained. New Roadmap will be published by the [Nordic Institute for Interoperability Solutions (NIIS)](https://niis.org) during spring 2018.
 
 # Abstract
 


### PR DESCRIPTION
The current version of the Roadmap is out-of-date and a new version of the Roadmap will be published by the NIIS during spring 2018. This should be stated in the beginning of the Roadmap document.